### PR TITLE
Avoid using __DIR__

### DIFF
--- a/includes/class-notify-users-e-mail-admin.php
+++ b/includes/class-notify-users-e-mail-admin.php
@@ -37,7 +37,7 @@ class Notify_Users_EMail_Admin {
 		add_action( 'admin_init', array( $this, 'plugin_settings' ) );
 
 		// Add an action link pointing to the options page.
-		$plugin_basename = plugin_basename( plugin_dir_path( __DIR__ ) . 'notify-users-e-mail' . '.php' );
+		$plugin_basename = plugin_basename( plugin_dir_path( __NTF_USR_FILE__ ) . 'notify-users-e-mail' . '.php' );
 		add_filter( 'plugin_action_links_' . $plugin_basename, array( $this, 'add_action_links' ) );
 	}
 

--- a/notify-users-e-mail.php
+++ b/notify-users-e-mail.php
@@ -27,6 +27,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
+define( '__NTF_USR_FILE__', __FILE__ );
+
 if ( ! class_exists( 'Notify_Users_EMail' ) ) :
 
 /**


### PR DESCRIPTION
As WordPress is compatible to PHP 5.2 this plugin should follow the same guidelines, and the  `__DIR__` constant is available only on PHP 5.3, so we removed it by passing the values of `__FILE__` on another constant to the included files.
