### PR TITLE
HTML entities in titles and email subjects

### DIFF
--- a/notify-users-e-mail.php
+++ b/notify-users-e-mail.php
@@ -455,6 +455,9 @@ class Notify_Users_EMail {
 			'Bcc: ' . implode( ',', $emails ),
 		);
 
+		// Decode HTML entities as email subjects are not parsed as HTML
+		$subject_post = html_entity_decode($subject_post, ENT_HTML5);
+
 		// Send the emails.
 		if ( apply_filters( 'notify_users_email_use_wp_mail', true ) ) {
 			wp_mail( '', $subject_post, $body_post, $headers );

--- a/notify-users-e-mail.php
+++ b/notify-users-e-mail.php
@@ -286,7 +286,7 @@ class Notify_Users_EMail {
 	 * @return string           New content.
 	 */
 	protected function apply_content_placeholders( $string, $post ) {
-		$string = str_replace( '{title}', sanitize_text_field( $post->post_title ), $string );
+		$string = str_replace( '{title}', sanitize_text_field( get_the_title( $post->ID ) ), $string );
 		$string = str_replace( '{link_post}', esc_url( get_permalink( $post->ID ) ), $string );
 		$string = str_replace( '{content_post}', apply_filters( 'the_content',get_post_field('post_content', $post->ID)), $string );
 		$string = str_replace( '{date}', $this->get_formated_date( $post->post_date ), $string );


### PR DESCRIPTION
Hi!

We noticed a situation recently where a title containing a `&` was displaying correctly in a lot of places but came through as `&amp;` in the email subject.

Here's our relevant configuration options:

"Email subject for new posts, pages and post types." is set to:

```
New post: {title}
```

"Email body for new posts, pages and post types." is set to:

```
<h3>{title}</h3>
{content_post}

{link_post}
```

A post was published recently with the title set to `D&amp;I`. This displayed correctly in the contents of posts on the website, and in the HTML body of the email that was sent. But it was displayed as `D&amp;I` in the email subject. Since email subjects aren't treated as HTML, HTML character entities can't be used, so this displayed as `D&amp;I` to users who received the emails.

This is caused by a combination of how titles are fetched, and a lack of decoding entities when preparing the email subject. The two attached commits address these two issues.

Thanks,
Mallory