### PR TITLE
Issue #99 Task: Add support for {excerpt_post} in email

### DIFF
--- a/includes/class-notify-users-e-mail-admin.php
+++ b/includes/class-notify-users-e-mail-admin.php
@@ -159,10 +159,11 @@ class Notify_Users_EMail_Admin {
 			'<p>',
 			'</p>',
 			sprintf(
-				'<ul><li><p><code>{title}</code> %s</p></li><li><p><code>{link_post}</code> %s</p></li><li><p><code>{content_post}</code> %s</p></li><li><p><code>{date}</code> %s</p></li></ul>',
+				'<ul><li><p><code>{title}</code> %s</p></li><li><p><code>{link_post}</code> %s</p></li><li><p><code>{content_post}</code> %s</p></li><li><p><code>{excerpt_post}</code> %s</p></li><li><p><code>{date}</code> %s</p></li></ul>',
 				__( 'to display the title', 'notify-users-e-mail' ),
 				__( 'to display the URL', 'notify-users-e-mail' ),
 				__( 'to display the content', 'notify-users-e-mail' ),
+				__( 'to display the excerpt', 'notify-users-e-mail' ),
 				__( 'to display the date of publication', 'notify-users-e-mail' )
 			)
 		);

--- a/notify-users-e-mail.php
+++ b/notify-users-e-mail.php
@@ -288,7 +288,8 @@ class Notify_Users_EMail {
 	protected function apply_content_placeholders( $string, $post ) {
 		$string = str_replace( '{title}', sanitize_text_field( get_the_title( $post->ID ) ), $string );
 		$string = str_replace( '{link_post}', esc_url( get_permalink( $post->ID ) ), $string );
-		$string = str_replace( '{content_post}', apply_filters( 'the_content',get_post_field('post_content', $post->ID)), $string );
+		$string = str_replace( '{content_post}', apply_filters( 'the_content', get_post_field('post_content', $post->ID)), $string );
+		$string = str_replace( '{excerpt_post}', apply_filters( 'the_content', get_post_field('post_excerpt', $post->ID)), $string );
 		$string = str_replace( '{date}', $this->get_formated_date( $post->post_date ), $string );
 
 		return $string;


### PR DESCRIPTION
Added the support for `{excerpt_post}` placeholder in email.
Please find the attachments for reference



**1. Setting the email template from configuration page.**
![configuration_page](https://user-images.githubusercontent.com/25909806/83288173-8e573100-a200-11ea-9ae4-ef800833cb21.png)




**2. Writing new blog post.**
![blog_post](https://user-images.githubusercontent.com/25909806/83288204-97480280-a200-11ea-8b54-3fc4a9f8ebc1.png)




**3. Received email after new blog post publish.**
![received_email](https://user-images.githubusercontent.com/25909806/83288219-9ca54d00-a200-11ea-9705-244d048fb8ee.png)
